### PR TITLE
Remove extra_params.

### DIFF
--- a/poki-sdk/manifests/web/engine_template.html
+++ b/poki-sdk/manifests/web/engine_template.html
@@ -18,9 +18,9 @@
 		});
 		Module['onRuntimeInitialized'] = function() {
 			PokiSDK.init().then(()=>{
-				Module.runApp("canvas", extra_params);
+				Module.runApp("canvas");
 			}).catch(()=>{
-				Module.runApp("canvas", extra_params);
+				Module.runApp("canvas");
 			});
 		};
 	</script>


### PR DESCRIPTION
In 1.7.1 version dmloader.js was reworked. No `extra_params` pass now.